### PR TITLE
Fix several issues running on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,10 @@ __pycache__/
 
 # Ignore sqlcmd binaries and archives
 sqlcmd*
+
+# Azurite storage emulator files
+__blobstorage__/
+__queuestorage__/
+__tablestorage__/
+__azurite_db*.json
+*.db

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "azureFunctions.projectLanguage": "C#",
     "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",
-    "azureFunctions.preDeployTask": "publish (functions)"
+    "azureFunctions.preDeployTask": "publish (functions)",
+    "dotnet.automaticallyCreateSolutionInWorkspace": false,
+    "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": false
 }

--- a/infra/scripts/configuresql.ps1
+++ b/infra/scripts/configuresql.ps1
@@ -67,8 +67,7 @@ if (-not (Test-Path $sqlcmdPath)) {
         exit 1
     }
     Write-Host "Downloading sqlcmd from: $URL"
-    $archiveExtension = if ($URL -like '*.zip') { '.zip' } elseif ($URL -like '*.tar.bz2') { '.tar.bz2' } elseif ($URL -like '*.tar.gz') { '.tar.gz' } else { '' }
-    $archivePath = Join-Path $SCRIPT_DIR "sqlcmd_download$archiveExtension"
+    $archivePath = Join-Path $SCRIPT_DIR 'sqlcmd_download'
     Invoke-WebRequest -Uri $URL -OutFile $archivePath
     if ($URL -like '*.tar.bz2') {
         tar -xjf $archivePath -C $SCRIPT_DIR

--- a/infra/scripts/configuresql.ps1
+++ b/infra/scripts/configuresql.ps1
@@ -67,7 +67,8 @@ if (-not (Test-Path $sqlcmdPath)) {
         exit 1
     }
     Write-Host "Downloading sqlcmd from: $URL"
-    $archivePath = Join-Path $SCRIPT_DIR 'sqlcmd_download'
+    $archiveExtension = if ($URL -like '*.zip') { '.zip' } elseif ($URL -like '*.tar.bz2') { '.tar.bz2' } elseif ($URL -like '*.tar.gz') { '.tar.gz' } else { '' }
+    $archivePath = Join-Path $SCRIPT_DIR "sqlcmd_download$archiveExtension"
     Invoke-WebRequest -Uri $URL -OutFile $archivePath
     if ($URL -like '*.tar.bz2') {
         tar -xjf $archivePath -C $SCRIPT_DIR

--- a/infra/scripts/configuresql.ps1
+++ b/infra/scripts/configuresql.ps1
@@ -75,7 +75,7 @@ if (-not (Test-Path $sqlcmdPath)) {
     } elseif ($URL -like '*.tar.gz') {
         tar -xzf $archivePath -C $SCRIPT_DIR
     } elseif ($URL -like '*.zip') {
-        Expand-Archive -Path $archivePath -DestinationPath $SCRIPT_DIR
+        Expand-Archive -Path $archivePath -DestinationPath $SCRIPT_DIR -Force
     } else {
         Write-Host "Unknown archive format for $URL"
         exit 1

--- a/infra/scripts/setuplocalenvironment.ps1
+++ b/infra/scripts/setuplocalenvironment.ps1
@@ -1,3 +1,4 @@
 $ErrorActionPreference = "Stop"
 .\infra\scripts\createlocalsettings.ps1
 .\infra\scripts\addclientip.ps1
+.\infra\scripts\configuresql.ps1

--- a/sql_output_http_trigger.cs
+++ b/sql_output_http_trigger.cs
@@ -18,7 +18,7 @@ public class SqlOutputBindingHttpTriggerCSharp
 
     // Visit https://aka.ms/sqlbindingsoutput to learn how to use this output binding
     [Function("httptrigger-sql-output")]
-    public async Task<OutputType> Run(
+    public OutputType Run(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
         [FromBody] ToDoItem toDoItem
     )
@@ -44,6 +44,6 @@ public class OutputType
     [SqlOutput("dbo.ToDo", connectionStringSetting: "AZURE_SQL_CONNECTION_STRING_KEY")]
     public required ToDoItem ToDoItem { get; set; }
 
-    //[HttpResponse]
+    [HttpResult]
     public required IActionResult HttpResponse { get; set; }
 }

--- a/sql_trigger.cs
+++ b/sql_trigger.cs
@@ -16,11 +16,51 @@ public static class ToDoTrigger
         var logger = context.GetLogger("ToDoTrigger");
         foreach (SqlChange<ToDoItem> change in changes)
         {
-            ToDoItem toDoItem = change.Item;
             logger.LogInformation($"Change operation: {change.Operation}");
-            logger.LogInformation(
-                $"Id: {toDoItem.Id}, Title: {toDoItem.title}, Url: {toDoItem.url}, Completed: {toDoItem.completed}"
-            );
+            
+            // Handle different operation types
+            switch (change.Operation)
+            {
+                case SqlChangeOperation.Insert:
+                case SqlChangeOperation.Update:
+                    // For INSERT and UPDATE operations, the Item contains the new/current values
+                    var toDoItem = change.Item;
+                    if (toDoItem != null)
+                    {
+                        logger.LogInformation(
+                            $"Id: {toDoItem.Id}, Title: {toDoItem.title}, Url: {toDoItem.url}, Completed: {toDoItem.completed}"
+                        );
+                    }
+                    else
+                    {
+                        logger.LogWarning($"{change.Operation} operation but item is null");
+                    }
+                    break;
+                    
+                case SqlChangeOperation.Delete:
+                    // For DELETE operations, we need to check what data is available
+                    // The Item might be null or have limited data since the row was deleted
+                    if (change.Item != null)
+                    {
+                        logger.LogInformation($"Deleted item Id: {change.Item.Id}");
+                        // Only log non-null properties for deletes
+                        if (!string.IsNullOrEmpty(change.Item.title))
+                            logger.LogInformation($"Deleted item Title: {change.Item.title}");
+                        if (!string.IsNullOrEmpty(change.Item.url))
+                            logger.LogInformation($"Deleted item Url: {change.Item.url}");
+                        if (change.Item.completed.HasValue)
+                            logger.LogInformation($"Deleted item Completed: {change.Item.completed}");
+                    }
+                    else
+                    {
+                        logger.LogInformation("Item was deleted but no item data is available");
+                    }
+                    break;
+                    
+                default:
+                    logger.LogWarning($"Unknown operation type: {change.Operation}");
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR includes these fixes:

+ [infra/scripts/setuplocalenvironment.ps1](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql/pull/12/files#diff-08a982a8cac7485ad69debfc8a899c4fc38a0aef989496f9fa3f0ee530602108): Added a call to the `configuresql.ps1` script, which wasn't being run on Windows.
+ [sql_trigger.cs](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql/pull/12/files#diff-0d27af2308ebc6640cafbc8316719da6c8f51e58e0b9c5182f6bfd2d3db7abee): added a check for operation type to prevent an exception on DELETEs. This was mostly GHCP, but it looks OK to me.
+ [sql_output_http_trigger.cs](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql/pull/12/files#diff-69262b899c2ef78e697734da8e5d4f560196acadcd67ac83b6e1cb5e60b074af): stop a warning about no awaits in the async method. Also, uncommented the HTTP trigger return attribute.
+ [infra/scripts/configuresql.ps1](https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql/pull/12/files#diff-ad3d022875bb98e2cdc8971a7450cf68570ab8a155a669031a4f25c1bb3a05ee): I was having trouble running the script on Windows, and GHCP helped me add this change, which SEEMS to have solved the issues. 