### PR TITLE
Migrate from Application Insights to OpenTelemetry

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2,13 +2,16 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
+using OpenTelemetry;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services
-    .AddApplicationInsightsTelemetryWorkerService()
-    .ConfigureFunctionsApplicationInsights();
+builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults()
+    .UseAzureMonitorExporter();
 
 builder.Build().Run();

--- a/Program.cs
+++ b/Program.cs
@@ -10,11 +10,17 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
+#if DEBUG
 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
 {
     builder.Services.AddOpenTelemetry()
         .UseFunctionsWorkerDefaults()
         .UseAzureMonitorExporter();
 }
+#else
+builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults()
+    .UseAzureMonitorExporter();
+#endif
 
 builder.Build().Run();

--- a/Program.cs
+++ b/Program.cs
@@ -10,8 +10,11 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    builder.Services.AddOpenTelemetry()
+        .UseFunctionsWorkerDefaults()
+        .UseAzureMonitorExporter();
+}
 
 builder.Build().Run();

--- a/functions-quickstart-dotnet-azd-sql.csproj
+++ b/functions-quickstart-dotnet-azd-sql.csproj
@@ -13,11 +13,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Sql" Version="3.1.376" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
-    <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Sql" Version="3.1.527" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/functions-quickstart-dotnet-azd-sql.csproj
+++ b/functions-quickstart-dotnet-azd-sql.csproj
@@ -10,9 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Sql" Version="3.1.376" />

--- a/host.json
+++ b/host.json
@@ -1,5 +1,6 @@
 {
     "version": "2.0",
+    "telemetryMode": "OpenTelemetry",
     "logging": {
         "applicationInsights": {
             "samplingSettings": {

--- a/host.json
+++ b/host.json
@@ -1,13 +1,4 @@
 {
     "version": "2.0",
-    "telemetryMode": "OpenTelemetry",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            },
-            "enableLiveMetricsFilters": true
-        }
-    }
+    "telemetryMode": "OpenTelemetry"
 }

--- a/sql_output_http_trigger.cs
+++ b/sql_output_http_trigger.cs
@@ -44,6 +44,6 @@ public class OutputType
     [SqlOutput("dbo.ToDo", connectionStringSetting: "AZURE_SQL_CONNECTION_STRING_KEY")]
     public required ToDoItem ToDoItem { get; set; }
 
-    //[HttpResponse]
+    [HttpResult]
     public required IActionResult HttpResponse { get; set; }
 }


### PR DESCRIPTION
## Purpose
* Migrate the sample from the Application Insights worker SDK to the OpenTelemetry approach for telemetry. Telemetry still flows to Application Insights via the Azure Monitor OpenTelemetry exporter.
* Mirrors the template change in [Azure/azure-functions-templates@1cc8df7](https://github.com/Azure/azure-functions-templates/commit/1cc8df7bb3807bad1641e44d604567a5f313814f).

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
* `csproj`: removed `Microsoft.ApplicationInsights.WorkerService` and `Microsoft.Azure.Functions.Worker.ApplicationInsights`; added `Microsoft.Azure.Functions.Worker.OpenTelemetry`, `OpenTelemetry.Extensions.Hosting`, and `Azure.Monitor.OpenTelemetry.Exporter`.
* `Program.cs`: replaced `AddApplicationInsightsTelemetryWorkerService` / `ConfigureFunctionsApplicationInsights` with `AddOpenTelemetry().UseFunctionsWorkerDefaults().UseAzureMonitorExporter()`.
* `host.json`: added `"telemetryMode": "OpenTelemetry"`.
* After deploying, telemetry continues to appear in the linked Application Insights resource.
